### PR TITLE
Support Deploying to GitHub Pages!

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]  # You can change this to match your default branch (main/master)
+  workflow_dispatch:    # Allows manual triggering of the workflow
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        
+      - name: Build project
+        run: yarn build
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'  # The folder containing your build output
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'yarn'
           
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install # --frozen-lockfile  I'm hacking together w/o pulling the code so package-lock.json isn't updated
         
       - name: Build project
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "webpack": "5.98.0",
     "webpack-cli": "6.0.1",
     "webpack-dev-server": "5.2.1",
-    "webpack-merge": "6.0.1"
+    "webpack-merge": "6.0.1",
+    "copy-webpack-plugin": "^13.0.0"
   },
   "scripts": {
     "start": "webpack serve --config ./webpack.develop.js",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,5 +18,17 @@ module.exports = {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
   },
+  plugins: [
+    new CopyWebpackPlugin({
+      patterns: [
+        { 
+          from: 'public', 
+          globOptions: {
+            ignore: ['**/style.css'] // Skip CSS file as it's referenced by the HTML
+          }
+        },
+      ],
+    }),
+  ],
 };
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,3 +1,4 @@
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
 
 module.exports = {


### PR DESCRIPTION
# GitHub Pages Deployment Setup

This PR adds GitHub Pages deployment capabilities to the project through a GitHub Actions workflow.

Changes include:
- Added `.github/workflows/deploy.yml` file that builds and deploys the game to GitHub Pages
- Added webpack configuration to properly copy static assets from public directory to dist

These changes enable automatic deployment to GitHub Pages whenever changes are pushed to the main branch. The game is now playable directly from the web without requiring users to clone and build the project locally.

To use this, repository owners simply need to enable GitHub Pages in their repository settings under Pages > Build and deployment > Source and select "GitHub Actions".

(End Auto-generated PR description...)

> [!NOTE]  
> Heads up, I added copy-webpack-plugin as a dev dependency, but didn't update the package-lock.json since I didn't clone the repo to my laptop, just hacked edits together from the browser until it worked 😅 
